### PR TITLE
Add http header for cross origin.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,12 @@ function Server(dir) {
     } else {
       yield next;
     }
+
+    this.set({
+      'Access-Control-Allow-Origin': '*',
+      'Timing-Allow-Origin': '*'
+    });
+
   });
 }
 


### PR DESCRIPTION
> Font from origin 'http://127.0.0.1:8000' has been blocked from loading by Cross-Origin Resource Sharing policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://127.0.0.1:8002' is therefore not allowed access.
